### PR TITLE
Add controlling macro into fixed-point.h

### DIFF
--- a/fixed-point.h
+++ b/fixed-point.h
@@ -1,4 +1,5 @@
 #ifndef FIXED_POINT_H
+#define FIXED_POINT_H
 
 #ifdef __KERNEL__
 #include <linux/types.h>


### PR DESCRIPTION
Avoid the compiling error of redefining fixed-point structure.